### PR TITLE
Add ssl option to pg Pool config

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ passwordless.init(new PostgreStore('postgres://user:password@localhost/database'
     pgstore: {
         table: 'not_default_table_name',    // *(String)* Optional. Use another table to store token, default is 'passwordless'
         pgPoolSize: '100'                   // *(Number)* Optional. Postgre client pool size
-    }
+    },
+    ssl: {rejectUnauthorized: false}, // *(boolean / { rejectUnauthorized: boolean})* Optional. Used to solve self signed cerificate error in pg npm module
 }));
 ```
 

--- a/lib/postgrestore.js
+++ b/lib/postgrestore.js
@@ -27,10 +27,12 @@ function PostgreStore(conString, options) {
     this._options.pgstore = this._options.pgstore || {};
     this._difficulty = this._options.pgstore.difficulty || 10;
 	this._table = this._options.pgstore.table || 'passwordless';
+    this._ssl = this._options.ssl || {};
 
     this._client = new pg.Pool({
+        ...(this._ssl) && {ssl: this._ssl},
         connectionString: conString,
-        max: this._options.pgstore.pgPoolSize || 10
+        max: this._options.pgstore.pgPoolSize || 10,
     });
 
     if(!isNumber(this._difficulty) || this._cost < 1) {


### PR DESCRIPTION
The updated pg npm (version > 8) returns self signed certificate error without ssl option on connecting to Heroku Postgres DB. 
Adding `ssl: {rejectUnauthorized: false}` to pg Pool config resolves the error